### PR TITLE
Break out pre-launch description from teaser

### DIFF
--- a/campaign-content-basics.txt
+++ b/campaign-content-basics.txt
@@ -49,8 +49,9 @@ The URL created for this page will be the same URL for the lifetime of the proje
 You'll work with your project manager to get your pre-launch "teaser" page set up. They will need:
 
 * Creator/Brand name
-* Project title and very brief description/teaser (120 chars. max). Often, this includes a short bullet list of features/functions.
-* Product Image
+* Project title and very brief teaser (120 chars. max)
+* Concise description of the project highlighting the main features that make it interesting. Often, this includes a short bullet list of features/functions.
+* Product image
 * Optional video or additional images
 * Optional project updates (i.e., a brief update on progress towards launch)
 


### PR DESCRIPTION
A creator believed that the pre-launch campaign body should be shorter than 120 char the way it was written. This little section could likely use some additional editing.